### PR TITLE
Fixes for Why Page

### DIFF
--- a/pages/why.textile
+++ b/pages/why.textile
@@ -284,7 +284,7 @@ the current version, Padrino comes with component choices for:
 Database Wrapper
 
 * ActiveRecord
-* Datamapper
+* DataMapper
 * Sequel
 * MongoMapper
 * Mongoid
@@ -296,7 +296,7 @@ Tests
 
 * Bacon
 * Shoulda
-* Rspec
+* RSpec
 * Riot
 * Cucumber
 * Testspec
@@ -304,9 +304,9 @@ Tests
 Javascripts
 
 * Prototype
-* Rightjs
+* RightJS
 * JQuery
-* mootools
+* MooTools
 * extcore
 * dojo
 
@@ -321,7 +321,7 @@ Stylesheets
 
 * Sass
 * Less
-* Scss
+* SCSS
 * Compass
 
 Mocks


### PR DESCRIPTION
- DRY is a mantra of Ruby on Rails not Ruby and Rails
- For whatever reason the teletype html tag doesn't work with the CSS setting that was set for how comments are rendered so rather than showing teletype it just shows the actual html tag. Likewise the CSS already changes the font to italic so I'm not sure if it will be easy to even notice teletype with italic and color. I would personally just not bother putting teletype. However, I'd fix it if you want to right now I removed it instead.
- You guys state that a Rails application is a Padrino project so stick with saying that or don't say it at all. Don't go back to saying an application when you mean a project.
- All these components have proper ways of spelling there names so make sure you do that. They spelled it with camel case or lowercase for whatever reason so respect the creators and maintainers of those projects decisions. I assume you would expect the same respect back.
