### PR TITLE
A section on exception handling

### DIFF
--- a/guides/exception-handling.textile
+++ b/guides/exception-handling.textile
@@ -1,0 +1,26 @@
+---
+:author: Foo Bar
+:title: Exception Handling
+---
+
+Padrino can handle exceptions raised inside your application. You can identify
+and handle error conditions by using HTTP status codes or by handling specific
+exceptions, like this: 
+
+<pre lang="ruby"><code># app/app.rb
+class YourApp < Padrino::Application
+
+  error ActiveRecord::RecordNotFound do
+    halt 404
+    render('errors/404')
+  end
+
+  error 404 do
+    render('errors/404')
+  end
+
+  error 500 do
+    render('errors/500')
+  end  
+end</code></pre>
+


### PR DESCRIPTION
Hi, I was wondering in irc whether there's a nice DRY way of handling exceptions in Padrino, and @roderyk pointed out that you can use the "error" method to handle specific sections in any way you want. 

A bunch of us were surprised as we hadn't seen this documented anywhere, so I've added a small section on exception handling to document this (sweet) behaviour. 

As a side note, although the last docs commit I did (#7) was merged, it hasn't been deployed yet, in case anybody's forgotten about it. 
