### PR TITLE
Update guides/controllers.textile, fixed url generated description in case  'get "/other/:id"'

### DIFF
--- a/guides/controllers.textile
+++ b/guides/controllers.textile
@@ -116,7 +116,7 @@ get "/show" do
 end
 
 get "/other/:id" do
-# url is generated as "/admin/#{params[:id]}"
+# url is generated as "/admin/other/#{params[:id]}"
 end
 end
 </code></pre>


### PR DESCRIPTION
in case 'get "/other/:id"' the url is generated as "/admin/other/#{params[:id]}", not "/admin/#{params[:id]}"
