### PR TITLE
Update whole examples page, fixes #81

### DIFF
--- a/guides/01_introduction/03_examples.html.md
+++ b/guides/01_introduction/03_examples.html.md
@@ -20,7 +20,7 @@ Name                                           | Description         | In Produc
 [itunes\_store\_transporter\_web](https://github.com/sshaw/itunes_store_transporter_web) | GUI for the iTunes Store’s Transporter (iTMSTransporter). | No | [sshaw](https://github.com/sshaw)
 [sochi2014 api](http://olympics.clearlytech.com/api-doc.html) | Unofficial olympics for sochi2014. | Yes, but API is no longer active | [clearytech](https://github.com/clearlytech)
 [dbd\_notebook](https://github.com/k2052/dbd_notebook) | Source code for notebook.designbreakdown.com (inactive since 2014). | No | [k2052](https://github.com/k2052)
-[manicminer-front](https://github.com/jorgefuertes/manicminer-front) | Manicminer Multicoin Mining Pool - Front App (inactive since 2014). | No (asked) | [jorgefuertes](https://github.com/jorgefuertes)
+[manicminer-front](https://github.com/jorgefuertes/manicminer-front) | Manicminer Multicoin Mining Pool - Front App (inactive since 2014). | No  [jorgefuertes](https://github.com/jorgefuertes)
 [fumblr](https://github.com/pengwynn/fumblr) | Stop fumbling with your Tumblr theme development (inactive since 2013). | No | [pengwynn](https://github.com/pengwynn)
 [machete](https://github.com/gtgames/machete) | Simple mongomapper+padrino driven web site engine (inactive since 2012). | No | [gtgames](https://github.com/gtgames)
 [shortener-demo]( https://github.com/padrino/shortener-demo) | Example Padrino url shortener app (inactive since 2011). | No | [achiu](https://github.com/achiu)

--- a/guides/01_introduction/03_examples.html.md
+++ b/guides/01_introduction/03_examples.html.md
@@ -15,10 +15,71 @@ Below is the current list of known open-source Padrino applications.
 
 Name                                           | Description         | In Production | Author
 ---------------------------------------------- | ------------------- | ------------- | ------------
-[test-app](http://github.com/padrino/test-app) | Sample padrino blog | No            | Padrino Team
+[padrino-web](https://github.com/padrino/padrino-web) | Open-sourced padrinorb.com source code. | Yes | [Padrino Team](https://github.com/orgs/padrino/teams/collaborators)
+[hasbeen.in](https://github.com/findoutwho/hasbeen.in) | Your geek-friendly travel site. | Yes | [findoutwho](https://github.com/findoutwho)
+[itunes\_store\_transporter\_web](https://github.com/sshaw/itunes_store_transporter_web) | GUI for the iTunes Store’s Transporter (iTMSTransporter). | No | [sshaw](https://github.com/sshaw)
+[sochi2014 api](http://olympics.clearlytech.com/api-doc.html) | Unofficial olympics for sochi2014. | Yes, but API is no longer active | [clearytech](https://github.com/clearlytech)
+[dbd\_notebook](https://github.com/k2052/dbd_notebook) | Source code for notebook.designbreakdown.com (inactive since 2014). | No | [k2052](https://github.com/k2052)
+[manicminer-front](https://github.com/jorgefuertes/manicminer-front) | Manicminer Multicoin Mining Pool - Front App (inactive since 2014). | No (asked) | [jorgefuertes](https://github.com/jorgefuertes)
+[fumblr](https://github.com/pengwynn/fumblr) | Stop fumbling with your Tumblr theme development (inactive since 2013). | No | [pengwynn](https://github.com/pengwynn)
+[machete](https://github.com/gtgames/machete) | Simple mongomapper+padrino driven web site engine (inactive since 2012). | No | [gtgames](https://github.com/gtgames)
+[shortener-demo]( https://github.com/padrino/shortener-demo) | Example Padrino url shortener app (inactive since 2011). | No | [achiu](https://github.com/achiu)
+[haircut](https://github.com/udzura/haircut) | The URL shortener with Padrino and MongoId (inactive since 2011). | No | [udzura](https://github.com/udzura)
+[moolah](https://github.com/mcmire/moolah) | A tiny money management app (inactive since 2011). | No | [mcmire](https://github.com/mcmire)
+[picciotto](https://github.com/apeacox/picciotto) | Minimalistic website framework (inactive since 2011). | No | [apeacox](https://github.com/apeacox)
+[fikas](https://github.com/bratta/fikus) | The Simple Ruby CMS (inactive since 2010). | No | [bratta](https://github.com/bratta)
+[pergola](https://github.com/ryanfitz/pergola) | Web frontend to mongoDB (inactive since 2011). | No | [ryanfitz](https://github.com/ryanfitz)
+[presto](https://github.com/pengwynn/presto) | Padrino + NestaCMS (inactive since 2010). | No | [pengwynn](http://wynnnetherland.com/)
+[shopping-cart](https://github.com/cored/shopping-cart) | The Rails shopping cart demo ported to the Padrino framework (inactive since 2010). | No | [cored](https://github.com/cored)
+[omerta](https://github.com/padrino/omerta) | Simple blog platform using Mongo Mapper, MongoDB and Padrino (inactive since 2010). | No | [zenom](https://github.com/zenom)
+[mashup](https://github.com/mwlang/mashup) | Displays various RSS feeds on one page (inactive since 2010). | No | [mwlang](https://github.com/mwlang)
+[padrino\_questionnaire](https://github.com/pepe/padrino_questionnaire) | Simple questionnaire application (inactive since 2011). | No | [pepe](https://github.com/pepe)
+
+
+## Web Libraries
+
+Name                                    | Description             | Author
+--------------------------------------- | ----------------------- | -------------
+[padrino-recipes](https://github.com/padrino/padrino-recipes) | Recipes for auto-installing various extra components into Padrino. | [Padrino](https://github.com/padrino)
+[padrino-contrib](https://github.com/padrino/padrino-contrib) | Extra libraries that are useful for use in Padrino. | [Padrino](https://github.com/padrino)
+[padrino-warden](https://github.com/jondot/padrino-warden) | Provides authentication for your Padrino application. | [jondot](https://github.com/jondot)
+[sinatra-simple-navigation](https://github.com/codeplant/sinatra-simple-navigation) | Creates a simple way to do navigation for Padrino and Sinatra. | [codeplant](https://github.com/codeplant)
+[padrino-pagination](https://github.com/sumskyi/padrino-pagination) | Pagination for Padrino (inactive since 2014). | [sumskyi](https://github.com/sumskyi)
+[padrino-fields](https://github.com/activestylus/padrino-fields) |  Simple, flexible form helpers for the Padrino Framework (inactive since 2013). | [activestylus](https://github.com/activestylus)
+[padrino-completion](https://github.com/bolshakov/padrino-completion) | Bash completion for Padrino (inactive since 2012). | [bolshakov](https://github.com/bolshakov)
+[vim-padrino](https://github.com/spllr/vim-padrino) | Vim support for Padrino (inactive since 2012). | [spllr](https://github.com/spllr)
+[ripl-padrino](https://github.com/achiu/ripl-padrino) | ripl console for Padrino applications (inactive since 2011). | [achiu](https://github.com/achiu)
+[padrino-responders](https://github.com/nu7hatch/padrino-responders) | Awesome way to remove redundancy in your Padrino controllers (inactive since 2011). | [nu7hatch](https://github.com/nu7hatch)
+[view\_models](https://github.com/floere/view_models) | A view model/representer solution for Padrino and Rails (inactive since 2012). | [floere](https://github.com/floere)
+[declarative\_authorization\_padrino](https://github.com/dariocravero/declarative_authorization_padrino) | Declarative Authorization for Padrino (inactive since 2011). | [dariocravero](https://github.com/dariocravero)
+[padrino-rpm](https://github.com/Asquera/padrino-rpm) | New Relic RPM for Padrino (inactive since 2011). | [Asquera](https://github.com/Asquera)
+[padrino-form-errors](https://github.com/nu7hatch/padrino-form-errors) | Simple way to handle errors more robustly (inactive since 2010). | [nu7hatch](https://github.com/nu7hatch)
+
 
 ## Closed-source Applications
 
 Name                                    | Description             | In Production | Author
 --------------------------------------- | ----------------------- | ------------- | ------------
-[Padrino Website](http://padrinorb.com) | Offical Padrino Website | Yes           | Padrino Team
+[Maptia](http://maptia.com/)            | A beautiful way to tell stories about places. | Yes | -
+[Brainfeed](http://brainfeed.org/)      | Back-end for iPad app that presents educational videos for kids | Yes | -
+[Coca Cola Enterprises](http://www.cokecce.com) | Coca Cola's European bottling arm. Webby award. | Yes           | -
+[jumpseller](http://jumpseller.com) | SaaS to create online stores | Yes            | -
+[FreshBSD](http://freshbsd.org) | FreshBSD is a search engine cataloguing the development of major BSD-associated software | Yes | [Thomas Hurst](http://hur.st/)
+[Smartmedia](http://www.smartmedia.cz) | Create advanced mobile, facebook and web applications | Yes | -
+[Otticalisotti](http://www.otticalisotti.com/) | | Yes | -
+
+
+Unknown if they still use Padrino, but I asked them:
+
+- http://www.idyllic-software.com
+- http://edenspiekermann.com
+- http://salin.org
+- http://www.videofy.me - VideofyMe helps bloggers make money with a slick video platform.
+- http://www.headlondon.com - London web agency using Padrino as its main dev framework
+- http://www.clearhaus.com - Acquiring merchant services
+- https://nofity.com - When notes meets social
+- http://landmoda.com - Networks for models in the world!
+- https://home.38degrees.org.uk - Campaign advocacy pages, fundraising and on-the-ground organising for Campaigning group 38 Degrees
+- http://martianoids.com - System administration company at Spain. Products and blog.
+- http://middlemanapp.com - Middleman: A Static Frontend Development Framework
+


### PR DESCRIPTION
I took the contents from https://github.com/padrino/padrino-framework/wiki/Projects-using-Padrino and ordered them descending according to their latest change date and categorize them into OS and closed source apps. 

The pages mentioned under the section "Unknown if they still use Padrino, but I asked them:" have been contacted and I'm waiting for their answer if they still use Padrino.

You can see a working example under <http://stagingpadrinorb.wikimatze.de/guides/introduction/examples/>

Cheers as always.