### PR TITLE
Add press page

### DIFF
--- a/guides/01_introduction/05_press.html.md
+++ b/guides/01_introduction/05_press.html.md
@@ -1,0 +1,30 @@
+---
+chapter: Introduction
+title: Press
+---
+
+# Press
+
+This is just a collection of links (news, blogs, etc) that mention Padrino and not directly authored by the core team:
+
+Name                                           | Description         | Author
+---------------------------------------------- | ------------------- | ------------
+[Cerner Tech Talk (Video)](https://www.youtube.com/watch?v=CH_a3yNbYDM) |  This talk is part of Cerner's Tech Talk series (2013).  | [@CernerEng](https://twitter.com/CernerEng)
+[O’Reilly Programming](http://radar.oreilly.com/2013/12/how-setting-aside-rails-and-picking-up-padrino-might-make-you-a-better-ruby-developer.html) | How Setting Aside Rails and Picking Up Padrino Might Make You a Better Ruby Developer (2013). | [Aaron Sumner](http://radar.oreilly.com/asumner)
+[RubyInside](http://www.rubyinside.com/padrino-sinatra-webapp-framework-3198.html) | Padrino: A Webapp Framework Wrapped Around Sinatra (2010). | [Peter Cooper](http://www.rubyinside.com/author/admin)
+[PuddingBowl](http://mph.puddingbowl.org/2011/04/padrino/) | padrino (2011). | [Michael Hall](http://mph.puddingbowl.org/about/)
+[JaxEnter](https://jaxenter.com/get-more-features-for-sinatra-100726.html) | Get More Features for Sinatra (2010)! | [Jessica Thornsby ](https://jaxenter.com/author/jessicathornsby)
+[HackerNews](https://news.ycombinator.com/item?id=1235078) | Padrino Ruby Web Framework (sits on top of Sinatra) - Release notes  | [jmonegro](https://news.ycombinator.com/user?id=jmonegro)
+[Ruby5](https://ruby5.codeschool.com/episodes/64-episode-62-march-26-2010) | Padrino got mentioned in this Podcast (2010).  | [Paul Elliott](http://uncle.ninja/)
+[coryodaniel](http://coryodaniel.com/index.php/tag/padrino/) | Some blog posts tackling problems with compass and sass (2010). | [Cory O'Daniel](http://coryodaniel.com/)
+[Ramaze vs. Padrino Benchmarks](http://codeconnoisseur.org/ramblings/ramaze-vs-padrino-benchmarks) | Ramaze vs. Padrino Benchmarks (2010). | [Michael Lang](http://codeconnoisseur.org/)
+[programmingzen](http://programmingzen.com/2010/06/11/padrino-a-ruby-framework-built-upon-sinatra/) | Padrino: a Ruby framework built upon Sinatra (2010).  | [Antonio Cangiano](http://programmingzen.com/about/)
+[changelog podcast](https://changelog.com/?s=padrino) | Several podcasts mentioning Padrino. | [changelog](https://changelog.com/about/)
+[Tropical Software Observation](http://tech.favoritemedium.com/2010/08/initial-review-on-padrino-fast-ruby-web.html) | Initial Thoughts on Padrino, a Fast Ruby Web Framework Based On Sinatra (2010) | [ Isak Rickyanto]()
+[trevmex](http://trevmex.com/post/934878009/padrino-and-sequel-for-lightweight-web-apps) | Padrino and Sequel for lightweight web apps (2010). | [trevmex](http://trevmex.com/)
+[Fikus](https://blog.engineyard.com/2010/fikus-deploying-padrino-to-engine-yard-appcloud) | Fikus: Deploying Padrino to Engine Yard AppCloud (2010). | [Tim Gourley](https://blog.engineyard.com/authors/Tim%20Gourley)
+[halfdecent](http://halfdecent.net/2010/08/20/installing-padrino-on-ubuntu-debian/) | Installing Padrino on Ubuntu / Debian (2010). | [Matt South](http://halfdecent.net/about/)
+[ruby-ua](http://ruby-ua.blogspot.de/2010/04/meet-padrino-part-1.html) | Russian page talking about Padrino (2010). | -
+[habrahabr](https://habrahabr.ru/post/94911/) | Russian page talking about Padrino (2010). | [Konstantin Shabanov](https://habrahabr.ru/users/Aesthete/)
+[cyberwave](http://cyberwave.jp/nashiki/2010/06/rails-%EF%BC%8B-sinatra-%E2%89%92-padrino-%E3%81%A7%E9%81%8A%E3%81%BC%E3%81%86%EF%BC%81/) | Japanese site mentioning Padrino (2010). | [nashik](http://cyberwave.jp/nashiki/)
+


### PR DESCRIPTION
I've updated the press releases mentioned Padrino and ordered them descending according to their latest change date.

You can see a working example under <http://stagingpadrinorb.wikimatze.de/guides/introduction/press>

Cheers as always.