### PR TITLE
Added :name to alias route definition with url_for

### DIFF
--- a/guides/05_controllers/02_routing.html.md
+++ b/guides/05_controllers/02_routing.html.md
@@ -95,14 +95,20 @@ specified controller group:
 
 ```ruby
 Demo::App.controllers "/admin" do
-  get "/show" do
+  get "/show", :name => :show do
     # url is generated as "/admin/show"
   end
 
-  get "/other/:id" do
+  get "/other/:id", :name => :other do
     # url is generated as "/admin/#{params[:id]}"
   end
 end
+```
+You can then reference these routes using the same `url_for` method:
+
+```haml
+= link_to 'admin show page', url_for(:admin, :show)
+= link_to 'admin index page', url_for(:admin, :other, :id => 25)
 ```
 
 ## Named Parameters


### PR DESCRIPTION
Hi there, I have found it very difficult to use `url_for` to get controller endpoints which were defined as an explicit relative url. After digging in Padrino's source code, I have found that you can add an action name which solves this problem. This is not something I found in the documentation, and I would like to contribute.

Please review :)
