### PR TITLE
Remove outdated documentation about Padrino.set_load_paths

### DIFF
--- a/guides/03_features/06_development-commands.html.md
+++ b/guides/03_features/06_development-commands.html.md
@@ -184,15 +184,3 @@ or `root/models`.
 
 If you have only one app you still use `project/app/models`(this is the default
 `padrino g` choice)
-
-Remember that if you need to load other paths you can use:
-
-```ruby
-Padrino.set_load_paths("path/one")
-```
-
-and if you need to load dependencies use:
-
-```ruby
-Padrino.require_dependencies("path/one/**/*.rb")
-```


### PR DESCRIPTION
The proper method of adding load paths is outlined earlier in the
documentation.

`Padrino.set_load_paths` was removed in 0.13.0.beta1